### PR TITLE
Multiple adjustments and rewrites

### DIFF
--- a/check_cpu_stats.sh
+++ b/check_cpu_stats.sh
@@ -2,21 +2,21 @@
 # ==============================================================================
 # CPU Utilization Statistics plugin for Nagios 
 #
-# Written by  : Steve Bosek
-# Patched by    :   Bas van der Doorn,Philipp Lemke
-# Release :   2.3.6
-# Creation date :   8 September 2007
-# Revision date :   5 August 2011
-# Package       :   BU Plugins
-# Description   :   Nagios plugin (script) to check cpu utilization 
-#                   statistics.
-#                   This script has been designed and written on Unix 
-#                   plateform (Linux, Aix, Solaris), 
-#                   requiring iostat as external program. The locations of 
-#                   these can easily be changed by editing the variables 
-#                   $IOSTAT at the top of the script. 
+# Original author:  Steve Bosek
+# Creation date:    8 September 2007
+# Description:      Monitoring plugin (script) to check cpu utilization statistics.
+#                   This script has been designed and written on Unix platforms
+#                   requiring iostat as external program.
 #                   The script is used to query 6 of the key cpu statistics
 #                   (user,system,iowait,steal,nice,idle) at the same time.
+# History/Changes:  HISTORY moved out of plugin into Git repository / README.md
+# License:          GNU General Public License v3.0 (GPL3), see LICENSE in Git repository
+#
+# Copyright 2007-2009,2011 Steve Bosek
+# Copyright 2008 Bas van der Doorn
+# Copyright 2008 Phlipp Lemke
+# Copyright 2016 Philip Dallig
+# Copyright 2022 Claudio Kuenzler
 #
 # USAGE  : ./check_cpu_stats.sh [-w <user,system,iowait>] [-c <user,system,iowait>] ( [ -i <intervals in second> ] [ -n <report number> ])
 #           
@@ -27,37 +27,12 @@
 # ----------------------------------------------------------------------------------------
 #
 # TODO:   - Support for MacOSX
-#         - Search Binary Path (iostat,sar) or Add Path parameter when other as default
 #
 # ========================================================================================
-#
-# HISTORY :
-#     Release |     Date    |    Authors       | Description
-# -------------+------------+------------------+------------------------------------------------------------------------------------
-#  2.0        | 16.02.08  | Steve Bosek        | Solaris support and new parameters 
-#                                                New Parameters : - iostat seconds intervals 
-#                                                                 - iostat report number
-#  2.1        | 08.06.08  | Steve Bosek        | Bug perfdata and convert comma in point for Linux result
-#  2.1.1      | 05.12.08  | Steve Bosek        | Fixed improperly terminated string that was left open at line 130 
-#  2.1.2      | 06.12.08  | Bas van der Doorn  | Fixed linux steal reported as idle, comparisons
-#  2.2        | 06.12.08  | Bas van der Doorn  | Capable systems will output nice and steal data
-#  2.2.1      | 06.12.08  | Steve Bosek        | Add for uniform Unix output nice and steal data on all perfdata  
-#  2.3        | 11.12.08  | Steve Bosek        | Add Threshold for user and system output with format -w user,system,iowait -c user,system,iowait
-#                                                Add Default parameters value for threshold if not define
-#                                                Add check for ${TAB_WARNING_THRESHOLD[@]} and ${TAB_CRITICAL_THRESHOLD[@]}
-#                                                Add verify for Critical CPU Threshold lower as Warning CPU threshold
-# 2.3.1       | 16.12.08  | Steve Bosek        | Potability AIX,SOLARIS,LINUX for table initialisation (TAB_WARNING_THRESHOLD and TAB_CRITICAL_THRESHOLD)   
-# 2.3.2       | 22.12.08  | Steve Bosek        | Strict Guideline Nagios for perfdata    
-# 2.3.3       | 08.02.08  | Philipp Lemke      | Add HP-UX support (tested on HP-UX B.11.23 U ia64) - steve bosek : uniform perfdata 
-# 2.3.4       | 29.03.09  | Steve Bosek        | Bug in line 176: return only critical state for warning condition for USER Stats.
-# 2.3.5       | 05.05.09  | Steve Bosek        | Bug fix in NAGIOS_DATA for HP-UX
-# 2.3.6       | 05.08.11  | Steve Bosek        | Bug fix in NAGIOS_DATA : replace comma with semicolon in perfdata - compatibility with pnp
 # -----------------------------------------------------------------------------------------
-
-
 # Paths to commands used in this script.  These may have to be modified to match your system setup.
-
-IOSTAT="/usr/bin/iostat"
+export PATH=$PATH:/usr/local/bin:/usr/bin:/bin # Set path
+IOSTAT="iostat"
 #Needed for HP-UX
 SAR="/usr/bin/sar"
 
@@ -67,46 +42,49 @@ STATE_WARNING=1
 STATE_CRITICAL=2
 STATE_UNKNOWN=3
 
-# Plugin parameters value if not define 
+# Plugin default parameters value if not defined
 LIST_WARNING_THRESHOLD=${LIST_WARNING_THRESHOLD:="70,40,30"}
 LIST_CRITICAL_THRESHOLD=${LIST_CRITICAL_THRESHOLD:="90,60,40"}
 INTERVAL_SEC=${INTERVAL_SEC:="1"}
 NUM_REPORT=${NUM_REPORT:="3"}
+# -----------------------------------------------------------------------------------------
 # Plugin variable description
 PROGNAME=$(basename $0)
-RELEASE="Revision 2.3.6"
-AUTHOR="(c) 2008 Steve Bosek (steve.bosek@gmail.com)"
-
+RELEASE="Revision 3.0.0"
+# -----------------------------------------------------------------------------------------
+# Check required commands
 if [ `uname` = "HP-UX" ];then
   if [ ! -x $SAR ]; then
     echo "UNKNOWN: sar not found or is not executable by the nagios user."
     exit $STATE_UNKNOWN
   fi
-else  
-  if [ ! -x $IOSTAT ]; then
-    echo "UNKNOWN: iostat not found or is not executable by the nagios user."
-    exit $STATE_UNKNOWN
+else
+  for cmd in iostat; do
+  if ! `which ${cmd} >/dev/null 2>&1`; then
+    echo "UNKNOWN: ${cmd} does not exist, please check if command exists and PATH is correct"
+    exit ${STATE_UNKNOWN}
   fi
+done
 fi
-
+# -----------------------------------------------------------------------------------------
 # Functions plugin usage
 print_release() {
-  echo "$RELEASE $AUTHOR"
+  echo "$RELEASE"
+  exit ${STATE_UNKNOWN}
 }
-
 
 print_usage() {
   echo ""
-  echo "$PROGNAME $RELEASE - CPU Utilization check script for Nagios"
+  echo "$PROGNAME $RELEASE - Monitoring plugin to check CPU Utilization"
   echo ""
-  echo "Usage: check_cpu_stats.sh -w -c (-i -n)"
+  echo "Usage: check_cpu_stats.sh [-w] [-c] [-i] [-n] [-b]"
   echo ""
   echo "  -w  Warning threshold in % for warn_user,warn_system,warn_iowait CPU (default : 70,40,30)"
-  echo "  Exit with WARNING status if cpu exceeds warn_n"
   echo "  -c  Critical threshold in % for crit_user,crit_system,crit_iowait CPU (default : 90,60,40)"
-  echo "  Exit with CRITICAL status if cpu exceeds crit_n"
   echo "  -i  Interval in seconds for iostat (default : 1)"
-  echo "  -n  Number report for iostat (default : 3)"
+  echo "  -n  Number of reports for iostat (default : 3)"
+  echo "  -b  The plugin will bail out and not collect CPU stats when condition matches (number of CPUs and process running), expects an input of N,process (e.g. 4,apache2)"
+  echo "  -v  Show version"
   echo "  -h  Show this page"
   echo ""
   echo "Usage: $PROGNAME"
@@ -118,50 +96,28 @@ print_usage() {
 print_help() {
   print_usage
     echo ""
-    echo "This plugin will check cpu utilization (user,system,CPU_Iowait,idle in %)"
+    echo "This plugin will check cpu utilization (user,system,iowait,idle in %)"
     echo ""
   exit 0
 }
-
+# -----------------------------------------------------------------------------------------
 # Parse parameters
-while [ $# -gt 0 ]; do
-    case "$1" in
-        -h | --help)
-            print_help
-            exit $STATE_OK
-            ;;
-        -v | --version)
-                print_release
-                exit $STATE_OK
-                ;;
-        -w | --warning)
-                shift
-                LIST_WARNING_THRESHOLD=$1
-                ;;
-        -c | --critical)
-               shift
-                LIST_CRITICAL_THRESHOLD=$1
-                ;;
-        -i | --interval)
-               shift
-               INTERVAL_SEC=$1
-                ;;
-        -n | --number)
-               shift
-               NUM_REPORT=$1
-                ;;        
-        *)  echo "Unknown argument: $1"
-            print_usage
-            exit $STATE_UNKNOWN
-            ;;
-        esac
-shift
+if [ "${1}" = "--help" ]; then print_help; exit $STATE_UNKNOWN; fi
+
+while getopts "c:w:i:n:b:hv" Input
+do
+  case ${Input} in
+  w)      LIST_WARNING_THRESHOLD=${OPTARG};;
+  c)      LIST_CRITICAL_THRESHOLD=${OPTARG};;
+  i)      INTERVAL_SEC=${OPTARG};;
+  n)      NUM_REPORT=${OPTARG};;
+  b)      BAIL=${OPTARG};;
+  h)      print_help;;
+  v)      print_release;;
+  *)      print_help;;
+  esac
 done
-
-
-
-
-
+# -----------------------------------------------------------------------------------------
 # List to Table for warning threshold
 TAB_WARNING_THRESHOLD=( `echo $LIST_WARNING_THRESHOLD | sed 's/,/ /g'` )
 if [ "${#TAB_WARNING_THRESHOLD[@]}" -ne "3" ]; then
@@ -188,11 +144,27 @@ if [ ${TAB_WARNING_THRESHOLD[0]} -ge ${TAB_CRITICAL_THRESHOLD[0]} -o ${TAB_WARNI
   echo "ERROR : Critical CPU Threshold lower as Warning CPU Threshold "
   exit $STATE_WARNING
 fi 
-  
 
+if [[ -n ${BAIL} ]]; then
+  BAIL_CPU=$(echo ${BAIL} | awk -F',' '{print $1}')
+  BAIL_PROCESS=$(echo ${BAIL} | awk -F',' '{print $2}')
+  if ! [[ ${BAIL_CPU} =~ ^[0-9]+$ ]]; then echo "ERROR: There was an error parsing the bail input. Verify your input. Seek help (-h)."; exit ${STATE_UNKNOWN}; fi
+fi
+# -----------------------------------------------------------------------------------------
 # CPU Utilization Statistics Unix Plateform ( Linux,AIX,Solaris are supported )
 case `uname` in
-  Linux ) CPU_REPORT=`iostat -c $INTERVAL_SEC $NUM_REPORT | sed -e 's/,/./g' | tr -s ' ' ';' | sed '/^$/d' | tail -1`
+  Linux )
+      # Bail out possible under certain situations
+      if [[ -n ${BAIL} ]]; then
+        BC_CPU=$(nproc)
+        BC_PROCESS=$(pgrep -n ${BAIL_PROCESS})
+        if [[ ${BAIL_CPU} -eq ${BC_CPU} && $(pgrep -n ${BAIL_PROCESS}) -gt 0 ]]; then
+          echo "CPU STATISTICS bailing out because of matched bailout patterns (CPU number ${BAIL_CPU} matches and process ${BAIL_PROCESS} is running)"
+          exit $STATE_OK
+        fi
+      fi
+
+      CPU_REPORT=`iostat -c $INTERVAL_SEC $NUM_REPORT | sed -e 's/,/./g' | tr -s ' ' ';' | sed '/^$/d' | tail -1`
       CPU_REPORT_SECTIONS=`echo ${CPU_REPORT} | grep ';' -o | wc -l`
       CPU_USER=`echo $CPU_REPORT | cut -d ";" -f 2`
       CPU_NICE=`echo $CPU_REPORT | cut -d ";" -f 3`
@@ -239,13 +211,13 @@ case `uname` in
       exit $STATE_UNKNOWN 
       ;;
 esac
-
+# -----------------------------------------------------------------------------------------
 # Add for integer shell issue
 CPU_USER_MAJOR=`echo $CPU_USER| cut -d "." -f 1`
 CPU_SYSTEM_MAJOR=`echo $CPU_SYSTEM | cut -d "." -f 1`
 CPU_IOWAIT_MAJOR=`echo $CPU_IOWAIT | cut -d "." -f 1`
 CPU_IDLE_MAJOR=`echo $CPU_IDLE | cut -d "." -f 1`
-
+# -----------------------------------------------------------------------------------------
 # Return
 if [ ${CPU_USER_MAJOR} -ge $USER_CRITICAL_THRESHOLD ]; then
     echo "CPU STATISTICS CRITICAL : ${NAGIOS_DATA}"
@@ -270,4 +242,5 @@ else
     exit $STATE_OK
 fi
 
-
+echo "CPU STATISTICS UNKNOWN: Should never reach this."
+exit $STATE_UNKNOWN


### PR DESCRIPTION
This is a rewrite of the check_cpu_stats plugin and contains several changes:

- Typo fixing and some styling adjustments
- Different way of reading user input (getopts)
- Using `$PATH` to support different path of iostat command
- Requirement check
- Moving history out of plugin itself into separate file (README for now)
- Adding a new parameter `-b` to define a so-called bailout situation (when matching the number of cpus and a certain process is running)