### PR TITLE
Several fixes and improvements, version 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ The script is a fork from the original check_cpu_stats plugin by Steve Bosek. It
 | ???   | 2016-06-11 | Philipp Dallig | Switch from ksh to bash |
 | 3.0.0   | 2022-12-16 | Claudio Kuenzler | Multiple changes, added `-b` parameters for bailing out under certain conditions |
 | 3.0.1   | 2022-12-16 | Claudio Kuenzler | Use pgrep -f for full process name in bailout check conditions |
+| 3.1.0   | 2022-12-19 | Claudio Kuenzler | Change to pidof to avoid hitting own process, support multiple bailout conditions (multple `-b N,process` possible) |


### PR DESCRIPTION
This PR adds fixes:

- Use `pidof` instead of `pgrep` to avoid listing own parent process listed and in the pgrep output and therefore always bailing out
- Support multiple bailout conditions by accepting multi-input (`-b 1,apache2 -b 1,nginx -b 1,puppet`)
- Use bailout conditions only under Linux (not able to test the other Operating Systems)