### PR TITLE
Change bailout process check back to pgrep

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ The script is a fork from the original check_cpu_stats plugin by Steve Bosek. It
 | 3.0.0   | 2022-12-16 | Claudio Kuenzler | Multiple changes, added `-b` parameters for bailing out under certain conditions |
 | 3.0.1   | 2022-12-16 | Claudio Kuenzler | Use pgrep -f for full process name in bailout check conditions |
 | 3.1.0   | 2022-12-19 | Claudio Kuenzler | Change to pidof to avoid hitting own process, support multiple bailout conditions (multple `-b N,process` possible) |
+| 3.1.1   | 2022-12-19 | Claudio Kuenzler | Change bailout process check back to pgrep to support process match with spaces (e.g. `-b "12,starter --daemon"`) |

--- a/check_cpu_stats.sh
+++ b/check_cpu_stats.sh
@@ -50,7 +50,7 @@ NUM_REPORT=${NUM_REPORT:="3"}
 # -----------------------------------------------------------------------------------------
 # Plugin variable description
 PROGNAME=$(basename $0)
-RELEASE="Revision 3.1.0"
+RELEASE="Revision 3.1.1"
 # -----------------------------------------------------------------------------------------
 # Check required commands
 if [ `uname` = "HP-UX" ];then
@@ -167,10 +167,10 @@ case `uname` in
       if [[ ${#BAIL[*]} -gt 0 ]]; then
         BC_CPU=$(nproc)
         o=0
-        for entry in ${BAIL[*]}; do
+        for entry in "${BAIL[*]}"; do
           BAIL_CPU[${o}]=$(echo "${entry}" | awk -F',' '{print $1}')
           BAIL_PROCESS[${o}]=$(echo "${entry}" | awk -F',' '{print $2}')
-          BC_PROCESS=$(pidof -s -x -o %PPID ${BAIL_PROCESS[${o}]})
+          BC_PROCESS=$(pgrep -fo "${BAIL_PROCESS[${o}]}")
           if [[ ${BAIL_CPU[${o}]} -eq ${BC_CPU} && ${BC_PROCESS} -gt 0 ]]; then
             echo "CPU STATISTICS OK - bailing out because of matched bailout patterns - ${NAGIOS_DATA}"
             exit $STATE_OK


### PR DESCRIPTION
Change back to `pgrep` instead of `pidof` because we want to support process matching on the full command line (including spaces and other characters), not just command name.  E.g. `-b "12,starter --daemon"`.