### PR TITLE
Using pidof again

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ The script is a fork from the original check_cpu_stats plugin by Steve Bosek. It
 | 3.1.0   | 2022-12-19 | Claudio Kuenzler | Change to pidof to avoid hitting own process, support multiple bailout conditions (multple `-b N,process` possible) |
 | 3.1.1   | 2022-12-19 | Claudio Kuenzler | Change bailout process check back to pgrep to support process match with spaces (e.g. `-b "12,starter --daemon"`) |
 | 3.1.2   | 2022-12-19 | Claudio Kuenzler | Bugfix in loop when using multiple bailout input |
+| 3.1.3   | 2022-12-19 | Claudio Kuenzler | Change to pidof to avoid hitting own process |

--- a/check_cpu_stats.sh
+++ b/check_cpu_stats.sh
@@ -27,7 +27,7 @@
 # -----------------------------------------------------------------------------------------
 # Plugin description
 PROGNAME=$(basename $0)
-RELEASE="Revision 3.1.2"
+RELEASE="Revision 3.1.3"
 
 # Paths to commands used in this script.  These may have to be modified to match your system setup.
 export PATH=$PATH:/usr/local/bin:/usr/bin:/bin # Set path
@@ -165,7 +165,7 @@ case `uname` in
 	while [ ${o} -lt ${#BAIL[*]} ]; do
           BAIL_CPU[${o}]=$(echo "${BAIL[${o}]}" | awk -F',' '{print $1}')
           BAIL_PROCESS[${o}]=$(echo "${BAIL[${o}]}" | awk -F',' '{print $2}')
-          BC_PROCESS=$(pgrep -fo "${BAIL_PROCESS[${o}]}")
+          BC_PROCESS=$(pidof "${BAIL_PROCESS[${o}]}")
           if [[ ${BAIL_CPU[${o}]} -eq ${BC_CPU} && ${BC_PROCESS} -gt 0 ]]; then
             echo "CPU STATISTICS OK - bailing out because of matched bailout patterns - ${NAGIOS_DATA}"
             exit $STATE_OK


### PR DESCRIPTION
Ran into that problem with self-process using pgrep again. The search patterns submitted with `-b` appear in the process output of the plugin itself. `pgrep` then thinks this is a running process and the condition matches. 
With `pidof` this doesn't happen, but requires some adjustment.

E.g. `-b "1,applying"` would not match a process `puppet agent: applying configuration`. The full process needs to be given here: `-b "1,puppet agent: applying configuration"`.