### PR TITLE
Change to ps aux to allow process matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ The script is a fork from the original check_cpu_stats plugin by Steve Bosek. It
 | 3.1.1   | 2022-12-19 | Claudio Kuenzler | Change bailout process check back to pgrep to support process match with spaces (e.g. `-b "12,starter --daemon"`) |
 | 3.1.2   | 2022-12-19 | Claudio Kuenzler | Bugfix in loop when using multiple bailout input |
 | 3.1.3   | 2022-12-19 | Claudio Kuenzler | Change to pidof to avoid hitting own process |
+| 3.1.4   | 2022-12-30 | Claudio Kuenzler | Change to ps aux to allow process matching, not just executable name |

--- a/check_cpu_stats.sh
+++ b/check_cpu_stats.sh
@@ -22,12 +22,12 @@
 #
 # Example: ./check_cpu_stats.sh
 #          ./check_cpu_stats.sh -w 70,40,30 -c 90,60,40
-#          ./check_cpu_stats.sh -w 70,40,30 -c 90,60,40 -i 3 -n 5 -b 1,apache2
+#          ./check_cpu_stats.sh -w 70,40,30 -c 90,60,40 -i 3 -n 5 -b '1,apache2' -b '1,running process'
 # ========================================================================================
 # -----------------------------------------------------------------------------------------
 # Plugin description
 PROGNAME=$(basename $0)
-RELEASE="Revision 3.1.3"
+RELEASE="Revision 3.1.4"
 
 # Paths to commands used in this script.  These may have to be modified to match your system setup.
 export PATH=$PATH:/usr/local/bin:/usr/bin:/bin # Set path
@@ -165,7 +165,7 @@ case `uname` in
 	while [ ${o} -lt ${#BAIL[*]} ]; do
           BAIL_CPU[${o}]=$(echo "${BAIL[${o}]}" | awk -F',' '{print $1}')
           BAIL_PROCESS[${o}]=$(echo "${BAIL[${o}]}" | awk -F',' '{print $2}')
-          BC_PROCESS=$(pidof "${BAIL_PROCESS[${o}]}")
+          BC_PROCESS=$(ps aux | grep "${BAIL_PROCESS[${o}]}" | egrep -v "(grep|check_cpu_stats)" | awk '{print $2}')
           if [[ ${BAIL_CPU[${o}]} -eq ${BC_CPU} && ${BC_PROCESS} -gt 0 ]]; then
             echo "CPU STATISTICS OK - bailing out because of matched bailout patterns - ${NAGIOS_DATA}"
             exit $STATE_OK


### PR DESCRIPTION
This changes the way the plugin searches for a PID of one of the bail out process matches (using `-b`). 
With `pgrep` and `pidof` only executable names (such as sshd, apache2, etc) can be matched, but not arguments or other strings in the cmdline. `ps aux` allows a grepping through that. 
