### PR TITLE
Fix issue 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ CPU STATISTICS OK - bailing out because of matched bailout patterns - user=0.50%
 | 3.1.2   | 2022-12-19 | Claudio Kuenzler | Bugfix in loop when using multiple bailout input |
 | 3.1.3   | 2022-12-19 | Claudio Kuenzler | Change to pidof to avoid hitting own process |
 | 3.1.4   | 2022-12-30 | Claudio Kuenzler | Change to ps aux to allow process matching, not just executable name |
+| 3.1.5   | 2023-12-07 | Claudio Kuenzler | Use `command` instead of `which` to find required commands (issue #7) |

--- a/check_cpu_stats.sh
+++ b/check_cpu_stats.sh
@@ -16,7 +16,7 @@
 # Copyright 2008 Bas van der Doorn
 # Copyright 2008 Philipp Lemke
 # Copyright 2016 Philipp Dallig
-# Copyright 2022 Claudio Kuenzler
+# Copyright 2022-2023 Claudio Kuenzler
 #
 # Usage:   ./check_cpu_stats.sh [-w <user,system,iowait>] [-c <user,system,iowait>] ( [-i <report interval>] [-n <report number> ] [-b <N,processname>])
 #
@@ -27,7 +27,7 @@
 # -----------------------------------------------------------------------------------------
 # Plugin description
 PROGNAME=$(basename $0)
-RELEASE="Revision 3.1.4"
+RELEASE="Revision 3.1.5"
 
 # Paths to commands used in this script.  These may have to be modified to match your system setup.
 export PATH=$PATH:/usr/local/bin:/usr/bin:/bin # Set path
@@ -55,7 +55,7 @@ if [ `uname` = "HP-UX" ];then
   fi
 else
   for cmd in iostat; do
-  if ! `which ${cmd} >/dev/null 2>&1`; then
+  if ! `command -v ${cmd} >/dev/null 2>&1`; then
     echo "UNKNOWN: ${cmd} does not exist, please check if command exists and PATH is correct"
     exit ${STATE_UNKNOWN}
   fi


### PR DESCRIPTION
Use `command` instead of `which` to find required commands. Fixes #7 .